### PR TITLE
Fix spelling of process

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ int main(void)
         /* Udev monitor poll DRM devices/connectors hotplugging events (-1 disables timeout).
          * To get a pollable FD use srmCoreGetMonitorFD() */
 
-        if (srmCoreProccessMonitor(core, -1) < 0)
+        if (srmCoreProcessMonitor(core, -1) < 0)
             break;
     }
 

--- a/doxygen/md/Tutorial.md
+++ b/doxygen/md/Tutorial.md
@@ -440,7 +440,7 @@ int main()
         /* Udev monitor poll DRM devices/connectors hotplugging events (-1 disables timeout).
          * To get a pollable FD use srmCoreGetMonitorFD() */
 
-        if (srmCoreProccessMonitor(core, -1) < 0)
+        if (srmCoreProcessMonitor(core, -1) < 0)
             break;
     }
 

--- a/src/examples/srm-all-connectors/main.c
+++ b/src/examples/srm-all-connectors/main.c
@@ -406,7 +406,7 @@ int main(void)
         /* Udev monitor poll DRM devices/connectors hotplugging events (-1 disables timeout).
          * To get a pollable FD use srmCoreGetMonitorFD() */
 
-        if (srmCoreProccessMonitor(core, 1000) < 0)
+        if (srmCoreProcessMonitor(core, 1000) < 0)
             break;
 
         // Update the background texture every second

--- a/src/examples/srm-basic/main.c
+++ b/src/examples/srm-basic/main.c
@@ -188,7 +188,7 @@ int main(void)
         /* Udev monitor poll DRM devices/connectors hotplugging events (-1 disables timeout).
          * To get a pollable FD use srmCoreGetMonitorFD() */
 
-        if (srmCoreProccessMonitor(core, -1) < 0)
+        if (srmCoreProcessMonitor(core, -1) < 0)
             break;
     }
 

--- a/src/examples/srm-multi-seat/main.c
+++ b/src/examples/srm-multi-seat/main.c
@@ -466,7 +466,7 @@ int main(void)
 
         // SRM
         if (fds[0].revents & POLLIN)
-            srmCoreProccessMonitor(core, 0);
+            srmCoreProcessMonitor(core, 0);
 
         // SEAT
         if (fds[1].revents & POLLIN)

--- a/src/lib/SRMCore.c
+++ b/src/lib/SRMCore.c
@@ -173,7 +173,7 @@ Int32 srmCoreGetMonitorFD(SRMCore *core)
     return core->monitorFd.fd;
 }
 
-Int32 srmCoreProccessMonitor(SRMCore *core, Int32 msTimeout)
+Int32 srmCoreProcessMonitor(SRMCore *core, Int32 msTimeout)
 {
     int ret = poll(&core->monitorFd, 1, msTimeout);
 

--- a/src/lib/SRMCore.h
+++ b/src/lib/SRMCore.h
@@ -129,7 +129,7 @@ Int32 srmCoreGetMonitorFD(SRMCore *core);
  *
  * @return The result of event processing. Typically, 0 on success, or -1 on error.
  */
-Int32 srmCoreProccessMonitor(SRMCore *core, Int32 msTimeout);
+Int32 srmCoreProcessMonitor(SRMCore *core, Int32 msTimeout);
 
 /**
  * @brief Registers a new listener to be invoked when a new device (GPU) becomes available.


### PR DESCRIPTION
Changes the spelling from proccess to process. As of yet untested though, that needs to be done.