### PR TITLE
build: heed results from pkg-config

### DIFF
--- a/doxygen/md/Tutorial.md
+++ b/doxygen/md/Tutorial.md
@@ -21,8 +21,8 @@ project('srm-example',
         version : '0.1.0')
 
 c = meson.get_compiler('c')
-
-glesv2_dep = c.find_library('GLESv2')
+pkg = import('pkgconfig')
+glesv2_dep = dependency('glesv2')
 srm_dep = c.find_library('SRM')
 
 include_directories_filtered = []

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,7 @@ endforeach
 # ------------ DEPENDENCIES ------------
 
 pkg              = import('pkgconfig')
+gl_dep           = dependency('gl')
 egl_dep          = dependency('egl')
 glesv2_dep       = dependency('glesv2')
 udev_dep         = dependency('libudev')
@@ -77,6 +78,7 @@ SRM = library(
     dependencies : [
         display_info_dep,
         egl_dep,
+        gl_dep,
         glesv2_dep,
         udev_dep,
         pthread_dep,

--- a/src/meson.build
+++ b/src/meson.build
@@ -56,13 +56,14 @@ endforeach
 
 # ------------ DEPENDENCIES ------------
 
-egl_dep          = c.find_library('EGL')
-glesv2_dep       = c.find_library('GLESv2')
-udev_dep         = c.find_library('udev')
+pkg              = import('pkgconfig')
+egl_dep          = dependency('egl')
+glesv2_dep       = dependency('glesv2')
+udev_dep         = dependency('libudev')
 pthread_dep      = c.find_library('pthread')
-drm_dep          = c.find_library('drm')
-gbm_dep          = c.find_library('gbm')
-display_info_dep = c.find_library('display-info')
+drm_dep          = dependency('libdrm')
+gbm_dep          = dependency('gbm')
+display_info_dep = dependency('libdisplay-info')
 
 # ------------ SOURCE CODE FILES ------------
 
@@ -95,8 +96,8 @@ endif
 
 if get_option('build_examples')
     m_dep = c.find_library('m')
-    libinput_dep = c.find_library('input')
-    libseat_dep = c.find_library('seat')
+    libinput_dep = dependency('libinput')
+    libseat_dep = dependency('libseat')
 
     subdir('examples/srm-basic')
     subdir('examples/srm-display-info')


### PR DESCRIPTION
The .pc files can have extra required flags or locations (e.g. if libraries are installed outside the standard search paths).