### PR TITLE
build: fix permission errors with ld.sh

### DIFF
--- a/scripts/ld.sh
+++ b/scripts/ld.sh
@@ -3,7 +3,7 @@
 # Fix linking problems
 
 set -e
-mkdir -p /etc/ld.so.conf.d
-echo $1 > /etc/ld.so.conf.d/srm.conf
-ldconfig
+mkdir -p ${DESTDIR}/etc/ld.so.conf.d
+echo "$1" >${DESTDIR}/etc/ld.so.conf.d/srm.conf
+/sbin/ldconfig -N ${DESTDIR}/
 exit 0


### PR DESCRIPTION
* First, ``make install`` with DESTDIR runs into a permission error with:

  + export DESTDIR=/home/abuild/rpmbuild/BUILDROOT/cuarzo-srm-0.3.2.1-0.x86_64
  + /usr/bin/meson install -C x86_64-suse-linux --no-rebuild /home/abuild/rpmbuild/BUILD/SRM-0.3.2-1/src/../scripts/ld.sh: line 7: /etc/ld.so.conf.d/srm.conf: Permission denied

* Second, ldconfig is in sbin, and sbin is not traditionally in PATH.

  /home/abuild/rpmbuild/BUILD/SRM-0.3.2-1/src/../scripts/ld.sh: line
  8: ldconfig: command not found

  (If sbin *is* in PATH, that is because Debian has a non-standard /etc/login.defs)

* Third, ldconfig itself runs into a permission error.

  /sbin/ldconfig: Can't create temporary cache file
  /etc/ld.so.cache.qf9tee: Permission denied

I think ld.sh should just be removed.