### PR TITLE
fix build with non-standard libdrm path

### DIFF
--- a/src/examples/srm-all-connectors/meson.build
+++ b/src/examples/srm-all-connectors/meson.build
@@ -2,6 +2,7 @@ executable(
     'srm-all-connectors',
     sources : ['main.c'],
     dependencies : [
+        drm_headers_dep,
         srm_dep,
         glesv2_dep,
         m_dep

--- a/src/examples/srm-basic/meson.build
+++ b/src/examples/srm-basic/meson.build
@@ -2,6 +2,7 @@ executable(
     'srm-basic',
     sources : ['main.c'],
     dependencies : [
+        drm_headers_dep,
         srm_dep,
         glesv2_dep,
         m_dep

--- a/src/examples/srm-display-info/meson.build
+++ b/src/examples/srm-display-info/meson.build
@@ -2,6 +2,7 @@ executable(
     'srm-display-info',
     sources : ['main.c'],
     dependencies : [
+        drm_headers_dep,
         srm_dep
     ],
     install : true)

--- a/src/examples/srm-multi-session/meson.build
+++ b/src/examples/srm-multi-session/meson.build
@@ -2,6 +2,7 @@ executable(
     'srm-multi-session',
     sources : ['main.c'],
     dependencies : [
+        drm_headers_dep,
         srm_dep,
         glesv2_dep,
         m_dep,

--- a/src/meson.build
+++ b/src/meson.build
@@ -59,8 +59,6 @@ include_paths = []
 
 include_paths_str = [
     './lib',
-    '/usr/include/drm',
-    '/usr/include/libdrm'
 ]
 
 foreach p : include_paths_str
@@ -82,6 +80,8 @@ drm_dep          = dependency('libdrm')
 gbm_dep          = dependency('gbm')
 display_info_dep = dependency('libdisplay-info')
 pthread_dep      = c.find_library('pthread')
+
+drm_headers_dep = drm_dep.partial_dependency(compile_args: true, includes: true)
 
 # ------------ SOURCE CODE FILES ------------
 


### PR DESCRIPTION
Without this, the examples can't find a libdrm include:
  ./SRMTypes.h:10:10: fatal error: drm_fourcc.h: No such file or directory

Note that when using meson partial_dependency(), 'compile_args' contains the gcc include paths, not 'includes'. Some discussion here at https://github.com/mesonbuild/meson/issues/7516